### PR TITLE
Fix build failing under linux due to url of in-project repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,9 +5,9 @@
     <artifactId>nb-darcula</artifactId>
     <version>1.3</version>
     <packaging>nbm</packaging>
-    
+
     <name>Darcula LAF for NetBeans</name>
-    
+
     <build>
         <plugins>
             <plugin>
@@ -43,7 +43,7 @@
             </plugin>
         </plugins>
     </build>
-    
+
     <repositories>
         <repository>
             <id>lib</id>
@@ -55,7 +55,7 @@
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
-            <url>file://${project.basedir}\lib</url>
+            <url>file:///${project.basedir}/lib</url>
         </repository>
         <repository>
             <id>netbeans</id>
@@ -66,7 +66,7 @@
             </snapshots>
         </repository>
     </repositories>
-    
+
     <dependencies>
         <!-- Darcula LAF -->
         <dependency>
@@ -85,7 +85,7 @@
             <artifactId>org-openide-modules</artifactId>
             <version>${netbeans.version}</version>
         </dependency>
-       
+
         <!-- For NbPreferences and Lookup -->
         <dependency>
             <groupId>org.netbeans.api</groupId>
@@ -118,7 +118,7 @@
             <version>${netbeans.version}</version>
         </dependency>
     </dependencies>
-    
+
     <properties>
         <netbeans.version>RELEASE80</netbeans.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Due to a backward slash the maven project fails to build under Linux.
Correcting the URL to use forward slashes only should make the project build on all platforms.