### PR TITLE
Hide exceptions stack traces in simple NetBeans Platform based apps

### DIFF
--- a/src/main/java/com/revivius/nb/darcula/Installer.java
+++ b/src/main/java/com/revivius/nb/darcula/Installer.java
@@ -71,8 +71,8 @@ public class Installer extends ModuleInstall {
             Object invokeResult = method.invoke(colorModel, new Object[0]);
             return invokeResult != null && !DarculaLaf.NAME.equals(invokeResult);
         } catch (Exception ex) {
-            //ignore
-            Logger.getLogger(Installer.class.getName()).log(Level.INFO, "Cannot get the current editor colors profile.", ex);
+            // log the problem
+            Logger.getLogger(Installer.class.getName()).log(Level.INFO, "Cannot get the current editor colors profile ({0}).", ex.getClass().getName());
         }
         return false;
     }


### PR DESCRIPTION
This PR "suppresses" the stacktraces logged by plugin when it tries to apply LAF tweaks by reflection and it does not find the java classes.
This scenario is frequent if you build simple applications based on the NetBeans Rich-Client Platform as those apps do not start with all NetBeans modules.

After applying the PR the log messages of the plugin in a typical NetBeans Platform application are reduced to:

```
...
INFO [com.revivius.nb.darcula.DarculaLFCustoms]: Could not tweak Darcula Look and Feel in the following classes:
    org.netbeans.modules.web.core.syntax.completion.api.JspCompletionItem (java.lang.ClassNotFoundException)
    org.netbeans.modules.editor.search.SearchBar (java.lang.ClassNotFoundException)
    org.netbeans.editor.GlyphGutter (java.lang.ClassNotFoundException)
    org.netbeans.modules.html.editor.api.completion.HtmlCompletionItem$Tag (java.lang.ClassNotFoundException)
    org.netbeans.modules.form.layoutdesign.LayoutPainter (java.lang.ClassNotFoundException)
    org.netbeans.modules.db.sql.editor.completion.SQLCompletionItem (java.lang.ClassNotFoundException)
    org.netbeans.modules.csl.editor.completion.GsfCompletionItem$CompletionFormatter (java.lang.ClassNotFoundException)
...
INFO [com.revivius.nb.darcula.Installer]: Cannot get the current editor colors profile (java.lang.ClassNotFoundException).
...
```

Fixes #96 and #69
